### PR TITLE
Migrate from Workers Sites to Workers Static Assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
         "@astrojs/cloudflare": "^13.1.7",
         "@astrojs/react": "^5.0.3",
         "@astrojs/sitemap": "^3.7.2",
-        "@cloudflare/kv-asset-handler": "^0.4.0",
         "@radix-ui/react-dialog": "^1.1.15",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "@astrojs/cloudflare": "^13.1.7",
     "@astrojs/react": "^5.0.3",
     "@astrojs/sitemap": "^3.7.2",
-    "@cloudflare/kv-asset-handler": "^0.4.0",
     "@radix-ui/react-dialog": "^1.1.15",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.4",

--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,8 +1,3 @@
-import { getAssetFromKV } from "@cloudflare/kv-asset-handler";
-import manifestJSON from "__STATIC_CONTENT_MANIFEST";
-
-const assetManifest = JSON.parse(manifestJSON);
-
 const ALLOWED_ORIGIN = "https://cologne.ravers.workers.dev";
 
 function corsHeaders(origin) {
@@ -28,95 +23,50 @@ export default {
       return handleNotifyEvent(request, env, ctx);
     }
 
-    return handleStaticAssets(request, env, ctx, url);
+    return handleStaticAssets(request, env, url);
   },
 };
 
-async function handleStaticAssets(request, env, ctx, url) {
-  const kvArgs = {
-    request,
-    waitUntil(promise) {
-      return ctx.waitUntil(promise);
-    },
-  };
-  const kvOptions = {
-    ASSET_NAMESPACE: env.__STATIC_CONTENT,
-    ASSET_MANIFEST: assetManifest,
-  };
+async function handleStaticAssets(request, env, url) {
+  const pathname = url.pathname;
+  const isHtmlRequest =
+    pathname === "/" ||
+    pathname.endsWith(".html") ||
+    pathname.endsWith(".htm") ||
+    !pathname.includes(".");
 
-  try {
-    const pathname = url.pathname;
-    const isHtmlRequest =
-      pathname === "/" ||
-      pathname.endsWith(".html") ||
-      pathname.endsWith(".htm") ||
-      (!pathname.includes(".") && pathname !== "/api/submit-event" && pathname !== "/api/notify-event");
+  const response = await env.ASSETS.fetch(request);
+  const headers = new Headers(response.headers);
 
-    if (isHtmlRequest) {
-      kvOptions.cacheControl = {
-        edgeTtl: 60 * 60,
-        browserTtl: 60 * 60,
-      };
-    } else {
-      kvOptions.cacheControl = {
-        edgeTtl: 30 * 24 * 60 * 60,
-        browserTtl: 24 * 60 * 60,
-      };
-    }
-
-    const response = await getAssetFromKV(kvArgs, kvOptions);
-    const headers = new Headers(response.headers);
-
-    // Cache headers per asset type
-    if (pathname.match(/\.(css|js)$/)) {
-      headers.set("Cache-Control", "public, max-age=31536000, immutable");
-    } else if (pathname.match(/\.(woff2?|ttf|otf|eot)$/)) {
-      headers.set("Cache-Control", "public, max-age=31536000, immutable");
-      headers.set("Access-Control-Allow-Origin", "*");
-    } else if (pathname.match(/\.(png|jpg|jpeg|gif|svg|webp|ico)$/)) {
-      headers.set("Cache-Control", "public, max-age=2592000");
-    } else if (isHtmlRequest) {
-      headers.set("Cache-Control", "public, max-age=3600, must-revalidate");
-    } else {
-      headers.set("Cache-Control", "public, max-age=86400");
-    }
-
-    // Security headers
-    headers.set("X-Content-Type-Options", "nosniff");
-    headers.set("X-Frame-Options", "DENY");
-    headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-
-    // Font preload for HTML pages
-    if (isHtmlRequest) {
-      headers.set(
-        "Link",
-        "</fonts/atkinson-regular.woff>; rel=preload; as=font; type=font/woff; crossorigin, </fonts/atkinson-bold.woff>; rel=preload; as=font; type=font/woff; crossorigin",
-      );
-    }
-
-    return new Response(response.body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers,
-    });
-  } catch (e) {
-    try {
-      const notFoundResponse = await getAssetFromKV(kvArgs, {
-        ...kvOptions,
-        mapRequestToAsset: (req) =>
-          new Request(`${new URL(req.url).origin}/404.html`, req),
-      });
-
-      return new Response(notFoundResponse.body, {
-        ...notFoundResponse,
-        status: 404,
-      });
-    } catch {
-      // 404.html not found
-    }
-
-    return new Response(e.message || e.toString(), { status: 500 });
+  if (pathname.match(/\.(css|js)$/)) {
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  } else if (pathname.match(/\.(woff2?|ttf|otf|eot)$/)) {
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+    headers.set("Access-Control-Allow-Origin", "*");
+  } else if (pathname.match(/\.(png|jpg|jpeg|gif|svg|webp|ico)$/)) {
+    headers.set("Cache-Control", "public, max-age=2592000");
+  } else if (isHtmlRequest) {
+    headers.set("Cache-Control", "public, max-age=3600, must-revalidate");
+  } else {
+    headers.set("Cache-Control", "public, max-age=86400");
   }
+
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+
+  if (isHtmlRequest) {
+    headers.set(
+      "Link",
+      "</fonts/atkinson-regular.woff>; rel=preload; as=font; type=font/woff; crossorigin, </fonts/atkinson-bold.woff>; rel=preload; as=font; type=font/woff; crossorigin",
+    );
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 async function handleAPIRequest(request, env, ctx) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,8 +4,11 @@
   "compatibility_flags": ["nodejs_compat"],
   "main": "workers-site/index.js",
 
-  "site": {
-    "bucket": "./dist"
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "run_worker_first": true,
+    "not_found_handling": "404-page"
   },
 
   "build": {


### PR DESCRIPTION
## Summary

- Replace legacy `site.bucket` (Workers Sites) with the modern `assets` binding.
- Fixes the intermittent `could not find <path>/index.XXXX.html in your content namespace` 500s caused by KV manifest/namespace drift.
- Custom cache/security/`Link` headers are preserved by setting `run_worker_first: true` and wrapping `env.ASSETS.fetch()` responses.
- Drops `@cloudflare/kv-asset-handler` (no longer needed).

## Changes

- `wrangler.jsonc`: `site.bucket` → `assets` (`directory`, `binding: ASSETS`, `run_worker_first: true`, `not_found_handling: "404-page"`).
- `workers-site/index.js`: swap `getAssetFromKV` for `env.ASSETS.fetch(request)`; keep all existing header logic intact. API routes (`/api/submit-event`, `/api/notify-event`) unchanged.
- `package.json` / `package-lock.json`: remove `@cloudflare/kv-asset-handler`.

## Test plan

- [x] `npm install` succeeds and lock file updates cleanly
- [x] `npm run deploy:dry-run` completes; `env.ASSETS` binding is reported
- [ ] After merge + deploy: `/`, `/form/`, `/parties/`, `/extract/`, `/favicon.svg`, `/sitemap-index.xml` all return 200
- [ ] HTML responses still include `Cache-Control`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, font-preload `Link`
- [ ] `/api/submit-event` GET returns `status: ok`