### PR TITLE
Bump js-yaml to 4.3.1 to fix CVE-2026-59870

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4761,9 +4761,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Fixes Dependabot alert #48 (high severity).

`js-yaml` 4.3.0 is vulnerable to quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870). Patched in 4.3.1.

Lockfile-only change — `package.json` already allows `^4.3.0`. Verified with a local `npm run build`.